### PR TITLE
Issue#14330

### DIFF
--- a/Tasks/Common/VstsAzureHelpers_/InitializeAzModuleFunctions.ps1
+++ b/Tasks/Common/VstsAzureHelpers_/InitializeAzModuleFunctions.ps1
@@ -143,7 +143,10 @@ function Initialize-AzSubscription {
             throw (New-Object System.Exception((Get-VstsLocString -Key AZ_MsiFailure), $_.Exception))
         }
         
-        Set-CurrentAzSubscription -SubscriptionId $Endpoint.Data.SubscriptionId -TenantId $Endpoint.Auth.Parameters.TenantId
+        if($scopeLevel -eq "Subscription")
+        {
+            Set-CurrentAzSubscription -SubscriptionId $Endpoint.Data.SubscriptionId -TenantId $Endpoint.Auth.Parameters.TenantId
+        }
     } else {
         throw (Get-VstsLocString -Key AZ_UnsupportedAuthScheme0 -ArgumentList $Endpoint.Auth.Scheme)
     } 


### PR DESCRIPTION
AzurePowerShell5 Task fails when Managed Identity Service Connection is Scoped to Management Group.

**Task name**: AzurePowerShell@5

**Description**: Issue14330 AzurePowerShell5 Task fails when Managed Identity Service Connection is Scoped to Management Group 

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** Y <https://github.com/microsoft/azure-pipelines-tasks/issues/14330>

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
